### PR TITLE
ImageToken - Cacheable Until

### DIFF
--- a/src/main/java/com/wix/mediaplatform/v8/auth/Token.java
+++ b/src/main/java/com/wix/mediaplatform/v8/auth/Token.java
@@ -53,6 +53,16 @@ public class Token {
         this.object = claims.get(Constants.OBJECT);
     }
 
+    public Token setIssuedAt(Long issuedAt) {
+        this.issuedAt = issuedAt;
+        return this;
+    }
+
+    public Token setTokenId(String tokenId) {
+        this.tokenId = tokenId;
+        return this;
+    }
+
     public Token setIssuer(String issuer) {
         this.issuer = issuer;
         return this;

--- a/src/main/java/com/wix/mediaplatform/v8/image/ImageToken.java
+++ b/src/main/java/com/wix/mediaplatform/v8/image/ImageToken.java
@@ -41,6 +41,12 @@ public class ImageToken extends Token {
         return this;
     }
 
+    public ImageToken cacheableUntil(Long expiration) {
+        this.setTokenId(expiration.toString());
+        this.setExpiration(expiration);
+        return (ImageToken) this.setIssuedAt(null);
+    }
+
     @Override
     public Map<String, Object> toClaims() {
         Map<String, Object> claims = super.toClaims();

--- a/src/test/java/com/wix/mediaplatform/v8/image/ImageTokenTest.java
+++ b/src/test/java/com/wix/mediaplatform/v8/image/ImageTokenTest.java
@@ -6,8 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.*;
 
 /**
  * Created by elad on 12/02/2020.
@@ -33,5 +32,23 @@ class ImageTokenTest {
         //noinspection unchecked
         assertThat((List<String>) claims.get("aud"), hasItem("urn:service:image.operations"));
         assertThat(((Map<String, Object>) claims.get("wmk")).get("gravity"), equalTo("south"));
+    }
+
+    @Test
+    void toClaimsWithCacheableUntil() {
+        Long expiration = 1000L;
+        Policy policy = new Policy()
+                .setMaxHeight(1000)
+                .setMaxWidth(1500)
+                .setPath("/path/to/image.jpg");
+        ImageToken token = new ImageToken().setPolicy(policy).cacheableUntil(expiration);
+
+        Map<String, Object> claims = token.toClaims();
+
+        //noinspection unchecked
+        assertThat((List<String>) claims.get("aud"), hasItem("urn:service:image.operations"));
+        assertThat(claims.get("iat"), nullValue());
+        assertThat(claims.get("jti"), is(expiration.toString()));
+        assertThat(claims.get("exp"), is(expiration));
     }
 }


### PR DESCRIPTION
Add cacheableUntil method to ImageToken, this method configures the token to be reproducible so that it does not invalidates the CDN cache when placed in the URL